### PR TITLE
Update Handlebars.NET

### DIFF
--- a/Lurgle.Alerting.Tests/Lurgle.Alerting.Tests.csproj
+++ b/Lurgle.Alerting.Tests/Lurgle.Alerting.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Lurgle.Alerting/Alert.cs
+++ b/Lurgle.Alerting/Alert.cs
@@ -20,6 +20,8 @@ using MailKit.Security;
 using static MimeMapping.MimeUtility;
 using Attachment = FluentEmail.Core.Models.Attachment;
 
+// ReSharper disable MethodOverloadWithOptionalParameter
+
 // ReSharper disable MemberCanBePrivate.Global
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 
@@ -283,9 +285,9 @@ namespace Lurgle.Alerting
         public IEnvelope Bcc(Dictionary<string, string> emailList)
         {
             foreach (var email in from email in emailList
-                let emailAddress = Alerting.GetEmailAddress(email.Key)
-                where !string.IsNullOrEmpty(emailAddress)
-                select email) BccAddresses.AddRange(ToAddressList(email.Key, email.Value));
+                     let emailAddress = Alerting.GetEmailAddress(email.Key)
+                     where !string.IsNullOrEmpty(emailAddress)
+                     select email) BccAddresses.AddRange(ToAddressList(email.Key, email.Value));
 
             return this;
         }
@@ -521,7 +523,7 @@ namespace Lurgle.Alerting
         {
             return GetEnvelopeWithBody(msg, true, altMsg, args);
         }
-        
+
         /// <summary>
         ///     Send the alert using the selected <see cref="RendererType" /> template and model
         /// </summary>
@@ -909,26 +911,26 @@ namespace Lurgle.Alerting
         {
             var domains = new List<string>();
             foreach (var toDomain in from to in ToAddresses
-                select to.EmailAddress.Split('@')[1]
-                into toDomain
-                where !string.IsNullOrEmpty(toDomain)
-                where !domains.Any(domain => domain.Equals(toDomain, StringComparison.OrdinalIgnoreCase))
-                select toDomain) domains.Add(toDomain);
+                     select to.EmailAddress.Split('@')[1]
+                     into toDomain
+                     where !string.IsNullOrEmpty(toDomain)
+                     where !domains.Any(domain => domain.Equals(toDomain, StringComparison.OrdinalIgnoreCase))
+                     select toDomain) domains.Add(toDomain);
 
             foreach (var ccDomain in from cc in CcAddresses
-                select cc.EmailAddress.Split('@')[1]
-                into ccDomain
-                where !string.IsNullOrEmpty(ccDomain)
-                where !domains.Any(domain => domain.Equals(ccDomain, StringComparison.OrdinalIgnoreCase))
-                select ccDomain) domains.Add(ccDomain);
+                     select cc.EmailAddress.Split('@')[1]
+                     into ccDomain
+                     where !string.IsNullOrEmpty(ccDomain)
+                     where !domains.Any(domain => domain.Equals(ccDomain, StringComparison.OrdinalIgnoreCase))
+                     select ccDomain) domains.Add(ccDomain);
 
 
             foreach (var bccDomain in from bcc in BccAddresses
-                select bcc.EmailAddress.Split('@')[1]
-                into bccDomain
-                where !string.IsNullOrEmpty(bccDomain)
-                where !domains.Any(domain => domain.Equals(bccDomain, StringComparison.OrdinalIgnoreCase))
-                select bccDomain) domains.Add(bccDomain);
+                     select bcc.EmailAddress.Split('@')[1]
+                     into bccDomain
+                     where !string.IsNullOrEmpty(bccDomain)
+                     where !domains.Any(domain => domain.Equals(bccDomain, StringComparison.OrdinalIgnoreCase))
+                     select bccDomain) domains.Add(bccDomain);
 
             return domains;
         }
@@ -1082,7 +1084,6 @@ namespace Lurgle.Alerting
         /// <param name="isMethod">Add the calling method to the message text if using <see cref="Send" /> to send an email</param>
         /// <param name="methodName">Automatically captures the calling method via [CallerMemberName]</param>
         /// <returns></returns>
-        // ReSharper disable once MemberCanBePrivate.Global
         public static IEnvelope From(string fromAddress = null, string fromName = null,
             AddressType addressType = AddressType.Email, bool isMethod = false,
             [CallerMemberName] string methodName = null)
@@ -1128,7 +1129,6 @@ namespace Lurgle.Alerting
         /// <param name="methodName">Automatically captures the calling method via [CallerMemberName]</param>
         /// <returns></returns>
         public static IEnvelope To(string toAddress = null, string toName = null,
-            // ReSharper disable once MethodOverloadWithOptionalParameter
             AddressType addressType = AddressType.Email, bool isMethod = false,
             [CallerMemberName] string methodName = null)
         {

--- a/Lurgle.Alerting/AlertConfig.cs
+++ b/Lurgle.Alerting/AlertConfig.cs
@@ -5,6 +5,9 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable RedundantCaseLabel
+
 namespace Lurgle.Alerting
 {
     /// <summary>
@@ -141,6 +144,10 @@ namespace Lurgle.Alerting
                 case null:
                     MailTlsOptions = TlsOptions.Auto;
                     break;
+                case TlsOptions.SslOnConnect:
+                case TlsOptions.StartTls:
+                default:
+                    break;
             }
 
             //Don't accept timeouts less than 1 second (unless 0, which disables the test), negatives, or higher than 20 seconds
@@ -159,13 +166,11 @@ namespace Lurgle.Alerting
         /// <summary>
         ///     Meaningful app name that is used for alerting. Will be auto-set if not specified.
         /// </summary>
-        // ReSharper disable once MemberCanBePrivate.Global
         public string AppName { get; private set; }
 
         /// <summary>
         ///     App version will be determined from the binary version, but can be overriden
         /// </summary>
-        // ReSharper disable once MemberCanBePrivate.Global
         public string AppVersion { get; private set; }
 
         /// <summary>
@@ -337,6 +342,10 @@ namespace Lurgle.Alerting
                     break;
                 case null:
                     alertConfig.MailTlsOptions = TlsOptions.Auto;
+                    break;
+                case TlsOptions.SslOnConnect:
+                case TlsOptions.StartTls:
+                default:
                     break;
             }
 

--- a/Lurgle.Alerting/Alerting.cs
+++ b/Lurgle.Alerting/Alerting.cs
@@ -12,6 +12,8 @@ using Lurgle.Alerting.Renderers;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 
+// ReSharper disable UnusedMethodReturnValue.Global
+
 namespace Lurgle.Alerting
 {
     /// <summary>
@@ -85,7 +87,6 @@ namespace Lurgle.Alerting
         /// <summary>
         ///     Initialise alerting and test availability of SMTP
         /// </summary>
-        // ReSharper disable once UnusedMethodReturnValue.Global
         public static bool Init()
         {
             if (Config == null) SetConfig();

--- a/Lurgle.Alerting/Lurgle.Alerting.csproj
+++ b/Lurgle.Alerting/Lurgle.Alerting.csproj
@@ -13,13 +13,16 @@
     <RepositoryUrl>https://github.com/MattMofDoom/Lurgle.Alerting</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>
     <PackageTags>Lurgle Fluent Email FluentEmail Alert Alerts Alerting Razor Fluid Liquid Smtp MailKit Handlebars template</PackageTags>
-    <Version>1.3.3</Version>
+    <Version>1.3.4</Version>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <MvcRazorExcludeRefAssembliesFromPublish>false</MvcRazorExcludeRefAssembliesFromPublish>
-    <PackageReleaseNotes>- Allow specifying multiple mail hosts as comma-delimited string for fallback capabilities
-- Add MailUseDns to delivery using DNS resolution of MX records
-- Add MailTlsOptions to allow specifying TLS behaviour
-- Bug fixes around attachments and alternate emails</PackageReleaseNotes>
+    <PackageReleaseNotes>
+      - Update Handlebars.NET
+      - Update System.Configuration.ConfigurationManager for supported frameworks
+      - Remove Microsoft.Windows.Compatibility as it doesn't appear to be required
+      - Add .NET 5.0 build of LurgleTest
+      - Add <PreserveCompilationContext>true</PreserveCompilationContext>  to LurgleTest for .NET 5.0 / .NET Core compatibility for RazorLight
+      - Code cleanup</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -36,13 +39,21 @@
     <PackageReference Include="FluentEmail.MailKit" Version="3.0.0" />
     <PackageReference Include="FluentEmail.Razor" Version="3.0.0" />
     <PackageReference Include="FluentEmail.Smtp" Version="3.0.0" />
-    <PackageReference Include="Handlebars.Net" Version="2.0.9" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
+    <PackageReference Include="Handlebars.Net" Version="2.0.10" />
     <PackageReference Include="MimeMapping" Version="1.0.1.37" />
     <PackageReference Include="RazorLight" Version="2.0.0-rc.3" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Unofficial.Microsoft.mshtml.NetStandard" Version="7.0.3300.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="System.Configuration.ConfigurationManager">
+      <Version>5.0.0</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Lurgle.Alerting/Renderers/FluentEmailHandlebarsBuilderExtensions.cs
+++ b/Lurgle.Alerting/Renderers/FluentEmailHandlebarsBuilderExtensions.cs
@@ -2,10 +2,11 @@
 using Lurgle.Alerting.Renderers;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
+// ReSharper disable CheckNamespace
+
 // ReSharper disable UnusedType.Global
 // ReSharper disable UnusedMember.Global
 
-// ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>

--- a/LurgleTest/LurgleTest.csproj
+++ b/LurgleTest/LurgleTest.csproj
@@ -2,11 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;net47;net48;</TargetFrameworks>
+    <TargetFrameworks>net461;net47;net48;net5.0</TargetFrameworks>
     <Version>1.2.2</Version>
     <Authors>Matt Marlor</Authors>
     <Company>Matt Marlor</Company>
     <IsPackable>false</IsPackable>
+    <!--This is required for .NET Core / .NET 5 projects-->
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update System.Configuration.ConfigurationManager for supported frameworks
Remove Microsoft.Windows.Compatibility as it doesn't appear to be required
Add .NET 5.0 build of LurgleTest
Add <PreserveCompilationContext>true</PreserveCompilationContext>  to LurgleTest for .NET 5.0 / .NET Core compatibility for RazorLight
Code cleanup